### PR TITLE
Fix  `ambiguous_associated_items` case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub fn derive_try_from_primitive(stream: TokenStream) -> TokenStream {
         impl ::std::convert::TryFrom<#repr> for #name {
             type Error=String;
 
-            fn try_from(number: #repr) -> Result<Self, Self::Error> {
+            fn try_from(number: #repr) -> Result<Self, String> {
                 #( const #match_const_names: #repeated_repr = #match_const_exprs; )*
 
                 match number {


### PR DESCRIPTION
Hello,

my enum looks like that:

```rust
#[derive(IntoPrimitive, TryFromPrimitive, Copy, Clone, PartialEq, Debug)]
#[repr(u8)]
pub enum BasicTokenNoPrefix {
    EndOfTokenisedLine = 0,
    StatementSeparator = 1,

    [...]
    Error,
    [...]
}
```

and I obtain this compilation error when using it:

```
error: ambiguous associated item
 --> src/basic/tokens.rs:7:10
  |
7 | #[derive(IntoPrimitive, TryFromPrimitive, Copy, Clone, PartialEq, Debug)]
  |          ^^^^^^^^^^^^^^^^
  |
  = note: #[deny(ambiguous_associated_items)] on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
note: `Error` could refer to variant defined here
 --> src/basic/tokens.rs:145:5
  |
14|     Error,
  |     ^^^^^
note: `Error` could also refer to associated type defined here
```


This patch allows to fix this issue.