### PR TITLE
Removed unconditional heap-allocation on TryFrom failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ rust:
   - nightly
 
 script:
-  - cargo test
-  - cargo test --features=complex-expressions
+  - cargo test --no-default-features --features="std"
+  - cargo test --no-default-features --features="std complex-expressions"
+  - cargo test --no-default-features --features=""
+  - cargo test --no-default-features --features="complex-expressions"
 
 matrix:
   include:
@@ -19,7 +21,7 @@ matrix:
       rust: stable
       script:
         - rustup target add thumbv6m-none-eabi
-        - cargo build --target=thumbv6m-none-eabi
+        - cargo build --target=thumbv6m-none-eabi --no-default-features
     - name: "cargo fmt"
       rust: stable
       script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ license = "BSD-3-Clause"
 proc-macro = true
 
 [features]
+std = []
 complex-expressions = ["syn/full"]
 external_doc = []
+
+default = ["std"]  # disable to use in a `no_std` environment
 
 [package.metadata.docs.rs]
 features = ["external_doc"]
@@ -25,6 +28,6 @@ travis-ci = { repository = "illicitonion/num_enum", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-proc-macro2 = "0.4.27"
-quote = "0.6.12"
-syn = "0.15.32"
+proc-macro2 = "0.4.30"
+proc-quote = "0.2.2"
+syn = "0.15.43"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() {
     let three = Number::try_from(3u8);
     assert_eq!(
         three.unwrap_err().to_string(),
-        "No value in enum `Number` for value `3`",
+        "No discriminant in enum `Number` matches the value `3`",
     );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ enum Number {
     One,
 }
 
-#[test]
-fn convert() {
+fn main() {
     let zero: u8 = Number::Zero.into();
     assert_eq!(zero, 0u8);
 }
@@ -35,7 +34,7 @@ Turning a primitive into an enum with try_from
 
 ```rust
 use num_enum::TryFromPrimitive;
-use std::convert::TryInto;
+use std::convert::TryFrom;
 
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
@@ -44,13 +43,15 @@ enum Number {
     One,
 }
 
-#[test]
-fn convert() {
-    let zero: Number = 0u8.try_into().unwrap();
+fn main() {
+    let zero = Number::try_from(0u8);
     assert_eq!(zero, Ok(Number::Zero));
 
-    let three: Result<Number, String> = 3u8.try_into();
-    assert_eq!(three, Err("No value in enum Number for value 3".to_owned()));
+    let three = Number::try_from(3u8);
+    assert_eq!(
+        three.unwrap_err().to_string(),
+        "No value in enum `Number` for value `3`",
+    );
 }
 ```
 
@@ -72,8 +73,7 @@ enum Number {
     One,
 }
 
-#[test]
-fn convert() {
+fn main() {
     unsafe {
         assert_eq!(
             Number::Zero,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,11 @@ extern crate proc_macro;
 use ::proc_macro::TokenStream;
 use ::proc_macro2::Span;
 use ::proc_quote::quote;
-use ::std::{iter::FromIterator, *};
+use ::std::iter::FromIterator;
 use ::syn::{
     parse::{Parse, ParseStream},
-    *,
+    parse_macro_input, parse_quote, Data, DeriveInput, Error, Expr, Ident, LitInt, LitStr, Meta,
+    Result,
 };
 
 macro_rules! die {
@@ -147,7 +148,10 @@ pub fn derive_try_from_primitive(input: TokenStream) -> TokenStream {
         });
 
     let no_match_message = LitStr::new(
-        &format!("No value in enum `{name}` for value `{{}}`", name = name),
+        &format!(
+            "No discriminant in enum `{name}` matches the value `{{}}`",
+            name = name
+        ),
         Span::call_site(),
     );
 
@@ -219,7 +223,7 @@ Transmutes `number: {repr}` into a [`{name}`].
 
 # Safety
 
-  - `number` must be a valid discriminant of [`{name}`]
+  - `number` must represent a valid discriminant of [`{name}`]
 "#,
             repr = repr,
             name = name,
@@ -238,19 +242,4 @@ Transmutes `number: {repr}` into a [`{name}`].
             }
         }
     })
-}
-
-mod doctest_readme {
-    macro_rules! with_doc {(
-        #[doc = $doc_string:expr]
-        $item:item
-    ) => (
-        #[doc = $doc_string]
-        $item
-    )}
-
-    with_doc! {
-        #[doc = include_str!("../README.md")]
-        extern {}
-    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -41,7 +41,7 @@ fn simple() {
     let three: Result<SimpleNumber, _> = 3u8.try_into();
     assert_eq!(
         three.unwrap_err().to_string(),
-        "No value in enum `SimpleNumber` for value `3`"
+        "No discriminant in enum `SimpleNumber` matches the value `3`"
     );
 }
 
@@ -61,7 +61,7 @@ fn even() {
     let one: Result<EvenNumber, _> = 1u8.try_into();
     assert_eq!(
         one.unwrap_err().to_string(),
-        "No value in enum `EvenNumber` for value `1`"
+        "No discriminant in enum `EvenNumber` matches the value `1`"
     );
 
     let two: Result<EvenNumber, _> = 2u8.try_into();
@@ -70,7 +70,7 @@ fn even() {
     let three: Result<EvenNumber, _> = 3u8.try_into();
     assert_eq!(
         three.unwrap_err().to_string(),
-        "No value in enum `EvenNumber` for value `3`"
+        "No discriminant in enum `EvenNumber` matches the value `3`"
     );
 
     let four: Result<EvenNumber, _> = 4u8.try_into();
@@ -97,7 +97,7 @@ fn skipped_value() {
     let two: Result<SkippedNumber, _> = 2u8.try_into();
     assert_eq!(
         two.unwrap_err().to_string(),
-        "No value in enum `SkippedNumber` for value `2`"
+        "No discriminant in enum `SkippedNumber` matches the value `2`"
     );
 
     let three: Result<SkippedNumber, _> = 3u8.try_into();
@@ -127,7 +127,7 @@ fn wrong_order() {
     let two: Result<WrongOrderNumber, _> = 2u8.try_into();
     assert_eq!(
         two.unwrap_err().to_string(),
-        "No value in enum `WrongOrderNumber` for value `2`"
+        "No discriminant in enum `WrongOrderNumber` matches the value `2`"
     );
 
     let three: Result<WrongOrderNumber, _> = 3u8.try_into();
@@ -166,7 +166,7 @@ mod complex {
 
         let three: Result<DifferentValuesNumber, _> = 3u8.try_into();
         assert_eq!(
-            three,unwrap          "No value in enum `DifferentValuesNumber` for value `3`"
+            three,unwrap          "No discriminant in enum `DifferentValuesNumber` matches the value `3`"
         );
 
         let four: Result<DifferentValuesNumber, _> = 4u8.try_into();
@@ -202,7 +202,7 @@ fn missing_trailing_comma() {
     let two: Result<MissingTrailingCommaNumber, _> = 2u8.try_into();
     assert_eq!(
         two.unwrap_err().to_string(),
-        "No value in enum `MissingTrailingCommaNumber` for value `2`"
+        "No discriminant in enum `MissingTrailingCommaNumber` matches the value `2`"
     );
 }
 
@@ -226,7 +226,7 @@ fn ignores_extra_attributes() {
     let two: Result<ExtraAttributes, _> = 2u8.try_into();
     assert_eq!(
         two.unwrap_err().to_string(),
-        "No value in enum `ExtraAttributes` for value `2`"
+        "No discriminant in enum `ExtraAttributes` matches the value `2`"
     );
 }
 
@@ -248,7 +248,7 @@ fn visibility_is_fine() {
     let two: Result<VisibleNumber, _> = 2u8.try_into();
     assert_eq!(
         two.unwrap_err().to_string(),
-        "No value in enum `VisibleNumber` for value `2`"
+        "No discriminant in enum `VisibleNumber` matches the value `2`"
     );
 }
 
@@ -270,7 +270,7 @@ fn error_variant_is_allowed() {
     let unknown: Result<HasErrorVariant, _> = 2u8.try_into();
     assert_eq!(
         unknown.unwrap_err().to_string(),
-        "No value in enum `HasErrorVariant` for value `2`"
+        "No discriminant in enum `HasErrorVariant` matches the value `2`"
     );
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -35,13 +35,13 @@ enum SimpleNumber {
 
 #[test]
 fn simple() {
-    let zero: Result<SimpleNumber, String> = 0u8.try_into();
+    let zero: Result<SimpleNumber, _> = 0u8.try_into();
     assert_eq!(zero, Ok(SimpleNumber::Zero));
 
-    let three: Result<SimpleNumber, String> = 3u8.try_into();
+    let three: Result<SimpleNumber, _> = 3u8.try_into();
     assert_eq!(
-        three,
-        Err("No value in enum SimpleNumber for value 3".to_owned())
+        three.unwrap_err().to_string(),
+        "No value in enum `SimpleNumber` for value `3`"
     );
 }
 
@@ -55,25 +55,25 @@ enum EvenNumber {
 
 #[test]
 fn even() {
-    let zero: Result<EvenNumber, String> = 0u8.try_into();
+    let zero: Result<EvenNumber, _> = 0u8.try_into();
     assert_eq!(zero, Ok(EvenNumber::Zero));
 
-    let one: Result<EvenNumber, String> = 1u8.try_into();
+    let one: Result<EvenNumber, _> = 1u8.try_into();
     assert_eq!(
-        one,
-        Err("No value in enum EvenNumber for value 1".to_owned())
+        one.unwrap_err().to_string(),
+        "No value in enum `EvenNumber` for value `1`"
     );
 
-    let two: Result<EvenNumber, String> = 2u8.try_into();
+    let two: Result<EvenNumber, _> = 2u8.try_into();
     assert_eq!(two, Ok(EvenNumber::Two));
 
-    let three: Result<EvenNumber, String> = 3u8.try_into();
+    let three: Result<EvenNumber, _> = 3u8.try_into();
     assert_eq!(
-        three,
-        Err("No value in enum EvenNumber for value 3".to_owned())
+        three.unwrap_err().to_string(),
+        "No value in enum `EvenNumber` for value `3`"
     );
 
-    let four: Result<EvenNumber, String> = 4u8.try_into();
+    let four: Result<EvenNumber, _> = 4u8.try_into();
     assert_eq!(four, Ok(EvenNumber::Four));
 }
 
@@ -88,22 +88,22 @@ enum SkippedNumber {
 
 #[test]
 fn skipped_value() {
-    let zero: Result<SkippedNumber, String> = 0u8.try_into();
+    let zero: Result<SkippedNumber, _> = 0u8.try_into();
     assert_eq!(zero, Ok(SkippedNumber::Zero));
 
-    let one: Result<SkippedNumber, String> = 1u8.try_into();
+    let one: Result<SkippedNumber, _> = 1u8.try_into();
     assert_eq!(one, Ok(SkippedNumber::One));
 
-    let two: Result<SkippedNumber, String> = 2u8.try_into();
+    let two: Result<SkippedNumber, _> = 2u8.try_into();
     assert_eq!(
-        two,
-        Err("No value in enum SkippedNumber for value 2".to_owned())
+        two.unwrap_err().to_string(),
+        "No value in enum `SkippedNumber` for value `2`"
     );
 
-    let three: Result<SkippedNumber, String> = 3u8.try_into();
+    let three: Result<SkippedNumber, _> = 3u8.try_into();
     assert_eq!(three, Ok(SkippedNumber::Three));
 
-    let four: Result<SkippedNumber, String> = 4u8.try_into();
+    let four: Result<SkippedNumber, _> = 4u8.try_into();
     assert_eq!(four, Ok(SkippedNumber::Four));
 }
 
@@ -118,22 +118,22 @@ enum WrongOrderNumber {
 
 #[test]
 fn wrong_order() {
-    let zero: Result<WrongOrderNumber, String> = 0u8.try_into();
+    let zero: Result<WrongOrderNumber, _> = 0u8.try_into();
     assert_eq!(zero, Ok(WrongOrderNumber::Zero));
 
-    let one: Result<WrongOrderNumber, String> = 1u8.try_into();
+    let one: Result<WrongOrderNumber, _> = 1u8.try_into();
     assert_eq!(one, Ok(WrongOrderNumber::One));
 
-    let two: Result<WrongOrderNumber, String> = 2u8.try_into();
+    let two: Result<WrongOrderNumber, _> = 2u8.try_into();
     assert_eq!(
-        two,
-        Err("No value in enum WrongOrderNumber for value 2".to_owned())
+        two.unwrap_err().to_string(),
+        "No value in enum `WrongOrderNumber` for value `2`"
     );
 
-    let three: Result<WrongOrderNumber, String> = 3u8.try_into();
+    let three: Result<WrongOrderNumber, _> = 3u8.try_into();
     assert_eq!(three, Ok(WrongOrderNumber::Three));
 
-    let four: Result<WrongOrderNumber, String> = 4u8.try_into();
+    let four: Result<WrongOrderNumber, _> = 4u8.try_into();
     assert_eq!(four, Ok(WrongOrderNumber::Four));
 }
 
@@ -155,31 +155,30 @@ mod complex {
 
     #[test]
     fn different_values() {
-        let zero: Result<DifferentValuesNumber, String> = 0u8.try_into();
+        let zero: Result<DifferentValuesNumber, _> = 0u8.try_into();
         assert_eq!(zero, Ok(DifferentValuesNumber::Zero));
 
-        let one: Result<DifferentValuesNumber, String> = 1u8.try_into();
+        let one: Result<DifferentValuesNumber, _> = 1u8.try_into();
         assert_eq!(one, Ok(DifferentValuesNumber::One));
 
-        let two: Result<DifferentValuesNumber, String> = 2u8.try_into();
+        let two: Result<DifferentValuesNumber, _> = 2u8.try_into();
         assert_eq!(two, Ok(DifferentValuesNumber::Two));
 
-        let three: Result<DifferentValuesNumber, String> = 3u8.try_into();
+        let three: Result<DifferentValuesNumber, _> = 3u8.try_into();
         assert_eq!(
-            three,
-            Err("No value in enum DifferentValuesNumber for value 3".to_owned())
+            three,unwrap          "No value in enum `DifferentValuesNumber` for value `3`"
         );
 
-        let four: Result<DifferentValuesNumber, String> = 4u8.try_into();
+        let four: Result<DifferentValuesNumber, _> = 4u8.try_into();
         assert_eq!(four, Ok(DifferentValuesNumber::Four));
 
-        let five: Result<DifferentValuesNumber, String> = 5u8.try_into();
+        let five: Result<DifferentValuesNumber, _> = 5u8.try_into();
         assert_eq!(five, Ok(DifferentValuesNumber::Five));
 
-        let six: Result<DifferentValuesNumber, String> = 6u8.try_into();
+        let six: Result<DifferentValuesNumber, _> = 6u8.try_into();
         assert_eq!(six, Ok(DifferentValuesNumber::Six));
 
-        let seven: Result<DifferentValuesNumber, String> = 7u8.try_into();
+        let seven: Result<DifferentValuesNumber, _> = 7u8.try_into();
         assert_eq!(seven, Ok(DifferentValuesNumber::Seven));
     }
 }
@@ -194,16 +193,16 @@ enum MissingTrailingCommaNumber {
 
 #[test]
 fn missing_trailing_comma() {
-    let zero: Result<MissingTrailingCommaNumber, String> = 0u8.try_into();
+    let zero: Result<MissingTrailingCommaNumber, _> = 0u8.try_into();
     assert_eq!(zero, Ok(MissingTrailingCommaNumber::Zero));
 
-    let one: Result<MissingTrailingCommaNumber, String> = 1u8.try_into();
+    let one: Result<MissingTrailingCommaNumber, _> = 1u8.try_into();
     assert_eq!(one, Ok(MissingTrailingCommaNumber::One));
 
-    let two: Result<MissingTrailingCommaNumber, String> = 2u8.try_into();
+    let two: Result<MissingTrailingCommaNumber, _> = 2u8.try_into();
     assert_eq!(
-        two,
-        Err("No value in enum MissingTrailingCommaNumber for value 2".to_owned())
+        two.unwrap_err().to_string(),
+        "No value in enum `MissingTrailingCommaNumber` for value `2`"
     );
 }
 
@@ -218,16 +217,16 @@ enum ExtraAttributes {
 
 #[test]
 fn ignores_extra_attributes() {
-    let zero: Result<ExtraAttributes, String> = 0u8.try_into();
+    let zero: Result<ExtraAttributes, _> = 0u8.try_into();
     assert_eq!(zero, Ok(ExtraAttributes::Zero));
 
-    let one: Result<ExtraAttributes, String> = 1u8.try_into();
+    let one: Result<ExtraAttributes, _> = 1u8.try_into();
     assert_eq!(one, Ok(ExtraAttributes::One));
 
-    let two: Result<ExtraAttributes, String> = 2u8.try_into();
+    let two: Result<ExtraAttributes, _> = 2u8.try_into();
     assert_eq!(
-        two,
-        Err("No value in enum ExtraAttributes for value 2".to_owned())
+        two.unwrap_err().to_string(),
+        "No value in enum `ExtraAttributes` for value `2`"
     );
 }
 
@@ -240,16 +239,16 @@ pub(crate) enum VisibleNumber {
 
 #[test]
 fn visibility_is_fine() {
-    let zero: Result<VisibleNumber, String> = 0u8.try_into();
+    let zero: Result<VisibleNumber, _> = 0u8.try_into();
     assert_eq!(zero, Ok(VisibleNumber::Zero));
 
-    let one: Result<VisibleNumber, String> = 1u8.try_into();
+    let one: Result<VisibleNumber, _> = 1u8.try_into();
     assert_eq!(one, Ok(VisibleNumber::One));
 
-    let two: Result<VisibleNumber, String> = 2u8.try_into();
+    let two: Result<VisibleNumber, _> = 2u8.try_into();
     assert_eq!(
-        two,
-        Err("No value in enum VisibleNumber for value 2".to_owned())
+        two.unwrap_err().to_string(),
+        "No value in enum `VisibleNumber` for value `2`"
     );
 }
 
@@ -262,16 +261,16 @@ pub enum HasErrorVariant {
 
 #[test]
 fn error_variant_is_allowed() {
-    let ok: Result<HasErrorVariant, String> = 0u8.try_into();
+    let ok: Result<HasErrorVariant, _> = 0u8.try_into();
     assert_eq!(ok, Ok(HasErrorVariant::Ok));
 
-    let err: Result<HasErrorVariant, String> = 1u8.try_into();
+    let err: Result<HasErrorVariant, _> = 1u8.try_into();
     assert_eq!(err, Ok(HasErrorVariant::Error));
 
-    let unknown: Result<HasErrorVariant, String> = 2u8.try_into();
+    let unknown: Result<HasErrorVariant, _> = 2u8.try_into();
     assert_eq!(
-        unknown,
-        Err("No value in enum HasErrorVariant for value 2".to_owned())
+        unknown.unwrap_err().to_string(),
+        "No value in enum `HasErrorVariant` for value `2`"
     );
 }
 


### PR DESCRIPTION
The main motivation for this PR is to stop using `String` as the `Error` type for the `TryFrom` conversion, since it means that a failed conversion will unconditionally heap-allocate an error message; such error message deserves to be lazily generated from within the `Display` `impl` of a custom `Error` type.

On top of that, the code has been simplified in some places for clarity, and the error messages generated by the `proc-macro` now have a more precise `Span` information.

Finally, the code in `README.md` is now automagically tested, which has led to fixing some errors in it.