### PR TITLE
Improved constant values generated code (issue #11)

### DIFF
--- a/num_enum_derive/src/lib.rs
+++ b/num_enum_derive/src/lib.rs
@@ -91,8 +91,9 @@ impl Parse for EnumInfo {
                     } else {
                         next_discriminant.clone()
                     };
+                    let ref variant_ident = variant.ident;
                     next_discriminant = parse_quote! {
-                        #repr::wrapping_add(#disc, 1)
+                        #repr::wrapping_add(#variant_ident, 1)
                     };
                     (disc, variant.ident)
                 }));


### PR DESCRIPTION
Co-authored-by: @glchapman

Fixes #11 

So the enum

```rust
#[derive(TryFromPrimitive)]
#[repr(u8)]
enum Example { A, B, C, D, E, F = 8, G, H, I, J, K, L, M, }
```

now generates:

```rust
impl ::num_enum::TryFromPrimitive for Example {
    // ...
    fn try_from_primitive(number: Self::Primitive)
     ->
         ::core::result::Result<Self,
                                ::num_enum::TryFromPrimitiveError<Self>> {
        #![allow(non_upper_case_globals)]
        const A: u8 = 0;
        const B: u8 = u8::wrapping_add(A, 1);
        const C: u8 = u8::wrapping_add(B, 1);
        const D: u8 = u8::wrapping_add(C, 1);
        const E: u8 = u8::wrapping_add(D, 1);
        const F: u8 = 8;
        const G: u8 = u8::wrapping_add(F, 1);
        const H: u8 = u8::wrapping_add(G, 1);
        const I: u8 = u8::wrapping_add(H, 1);
        const J: u8 = u8::wrapping_add(I, 1);
        const K: u8 = u8::wrapping_add(J, 1);
        const L: u8 = u8::wrapping_add(K, 1);
        const M: u8 = u8::wrapping_add(L, 1);
```