### PR TITLE
Upgrade to derivative 2.0

### DIFF
--- a/num_enum/Cargo.toml
+++ b/num_enum/Cargo.toml
@@ -28,5 +28,5 @@ travis-ci = { repository = "illicitonion/num_enum", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-derivative = { version = "1.0.2", features = ["use_core"] }
+derivative = { version = "2", features = ["use_core"] }
 num_enum_derive = { version = "0.4.2", path = "../num_enum_derive", default-features = false }


### PR DESCRIPTION
There are no changes in this release of derivative; it just brings in
transitive dependencies on stable releases of proc-macro2/syn/quote.