### PR TITLE
Pass manifest path on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ rust:
   - nightly
 
 script:
-  - cargo test --no-default-features --features="std"
-  - cargo test --no-default-features --features="std complex-expressions"
-  - cargo test --no-default-features --features=""
-  - cargo test --no-default-features --features="complex-expressions"
+  - cargo test --manifest-path=num_enum/Cargo.toml --no-default-features --features="std"
+  - cargo test --manifest-path=num_enum/Cargo.toml --no-default-features --features="std complex-expressions"
+  - cargo test --manifest-path=num_enum/Cargo.toml --no-default-features --features=""
+  - cargo test --manifest-path=num_enum/Cargo.toml --no-default-features --features="complex-expressions"
 
 matrix:
   include:


### PR DESCRIPTION
Cargo stopped allowing feature flags in virtual manifests.