### PR TITLE
Fix no_std support if serde is depended on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ matrix:
         - rustup target add thumbv6m-none-eabi
         # Need to cd because of https://github.com/rust-lang/cargo/issues/5364
         - (cd num_enum && cargo build --target=thumbv6m-none-eabi --no-default-features -p num_enum)
-        - (cd renamed_num_enum && cargo build --target=thumbv6m-none-eabi --no-default-features -p renamed_num_enum --lib)
+        # Regression test for https://github.com/illicitonion/num_enum/issues/18
+        - (cd serde_example && cargo build --target=thumbv6m-none-eabi -p serde_example --lib)
     - name: "cargo fmt"
       rust: stable
       script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["num_enum", "num_enum_derive", "renamed_num_enum"]
+members = ["num_enum", "num_enum_derive", "renamed_num_enum", "serde_example"]
 # Exclude num_enum_derive because its useful doc comments import num_enum, which the crate doesn't do (because it would
 # cause a circular dependency), so the doc tests don't actually compile.
-default-members  = ["num_enum", "renamed_num_enum"]
+default-members  = ["num_enum", "renamed_num_enum", "serde_example"]

--- a/num_enum_derive/Cargo.toml
+++ b/num_enum_derive/Cargo.toml
@@ -16,7 +16,11 @@ license = "BSD-3-Clause"
 proc-macro = true
 
 [features]
-std = []
+# Don't depend on proc-macro-crate in no_std environments because it causes an awkward depndency
+# on serde with std.
+#
+# See https://github.com/illicitonion/num_enum/issues/18
+std = ["proc-macro-crate"]
 complex-expressions = ["syn/full"]
 external_doc = []
 
@@ -27,6 +31,6 @@ features = ["external_doc"]
 
 [dependencies]
 proc-macro2 = "1"
-proc-macro-crate = "0.1.4"
+proc-macro-crate = { version = "0.1.4", optional = true }
 quote = "1"
 syn = "1"

--- a/renamed_num_enum/Cargo.toml
+++ b/renamed_num_enum/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.0.0"
 edition = "2018"
 publish = false
 
-[features]
-std = ["renamed/std"]
-
 [dependencies.renamed]
 package = "num_enum"
 path = "../num_enum"
 default-features = false
+features = ["std"]

--- a/serde_example/Cargo.toml
+++ b/serde_example/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "serde_example"
+version = "0.1.0"
+authors = [
+  "Daniel Wagner-Hall <dawagner@gmail.com>",
+  "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
+]
+description = "Example crate using num_enum and serde. Regression test for https://github.com/illicitonion/num_enum/issues/18."
+edition = "2018"
+repository = "https://github.com/illicitonion/num_enum"
+publish = false
+
+[dependencies]
+num_enum = { path = "../num_enum", default-features = false }
+serde = { version = "1", default_features = false, features = ["derive"] }

--- a/serde_example/src/lib.rs
+++ b/serde_example/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_std]
+
+use num_enum::{IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, IntoPrimitive, Serialize, TryFromPrimitive, UnsafeFromPrimitive)]
+#[repr(u8)]
+pub enum Number {
+    Zero,
+    One,
+}


### PR DESCRIPTION
The proc-macro-crate depends on toml, which in turn depends on serde
_with_ std. Only depend on proc-macro-crate if std is enabled.

This means that no_std consumer of num_enum cannot rename their num_enum
dependency. This seems like a reasonable restriction.

Works around https://github.com/rust-lang/cargo/issues/5730

Fixes #18 