### PR TITLE
Ensure tests detect a regression of #27 + re-enabled no_std test back

### DIFF
--- a/num_enum/tests/from_primitive.rs
+++ b/num_enum/tests/from_primitive.rs
@@ -1,6 +1,12 @@
-use std::convert::TryFrom;
+use ::std::convert::TryFrom;
 
-use num_enum::{FromPrimitive, TryFromPrimitive};
+use ::num_enum::{FromPrimitive, TryFromPrimitive};
+
+// Guard against https://github.com/illicitonion/num_enum/issues/27
+mod alloc {}
+mod core {}
+mod num_enum {}
+mod std {}
 
 #[test]
 fn has_from_primitive_number() {

--- a/num_enum/tests/into_primitive.rs
+++ b/num_enum/tests/into_primitive.rs
@@ -1,4 +1,10 @@
-use num_enum::IntoPrimitive;
+use ::num_enum::IntoPrimitive;
+
+// Guard against https://github.com/illicitonion/num_enum/issues/27
+mod alloc {}
+mod core {}
+mod num_enum {}
+mod std {}
 
 #[derive(IntoPrimitive)]
 #[repr(u8)]

--- a/num_enum/tests/renamed_num_enum.rs
+++ b/num_enum/tests/renamed_num_enum.rs
@@ -1,36 +1,33 @@
-#![cfg_attr(rustfmt, rustfmt::skip)] // args
-
 #[test]
 fn no_std() {
-    assert!(
-        ::std::process::Command::new("cargo")
+    assert!(::std::process::Command::new("cargo")
         .args(&[
             "run",
-            "--manifest-path", concat!(
+            "--manifest-path",
+            concat!(
                 env!("CARGO_MANIFEST_DIR"),
                 "/../renamed_num_enum/Cargo.toml",
             ),
         ])
         .status()
         .unwrap()
-        .success()
-    )
+        .success())
 }
 
 #[test]
 fn std() {
-    assert!(
-        ::std::process::Command::new("cargo")
+    assert!(::std::process::Command::new("cargo")
         .args(&[
             "run",
-            "--manifest-path", concat!(
+            "--manifest-path",
+            concat!(
                 env!("CARGO_MANIFEST_DIR"),
                 "/../renamed_num_enum/Cargo.toml",
             ),
-            "--features", "std",
+            "--features",
+            "std",
         ])
         .status()
         .unwrap()
-        .success()
-    )
+        .success())
 }

--- a/num_enum/tests/renamed_num_enum.rs
+++ b/num_enum/tests/renamed_num_enum.rs
@@ -1,13 +1,36 @@
+#![cfg_attr(rustfmt, rustfmt::skip)] // args
+
 #[test]
-fn main() {
-    assert!(::std::process::Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path")
-        .arg(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../renamed_num_enum/Cargo.toml",
-        ))
+fn no_std() {
+    assert!(
+        ::std::process::Command::new("cargo")
+        .args(&[
+            "run",
+            "--manifest-path", concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../renamed_num_enum/Cargo.toml",
+            ),
+        ])
         .status()
         .unwrap()
-        .success())
+        .success()
+    )
+}
+
+#[test]
+fn std() {
+    assert!(
+        ::std::process::Command::new("cargo")
+        .args(&[
+            "run",
+            "--manifest-path", concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../renamed_num_enum/Cargo.toml",
+            ),
+            "--features", "std",
+        ])
+        .status()
+        .unwrap()
+        .success()
+    )
 }

--- a/num_enum/tests/try_from_primitive.rs
+++ b/num_enum/tests/try_from_primitive.rs
@@ -1,6 +1,12 @@
-use std::convert::{TryFrom, TryInto};
+use ::std::convert::{TryFrom, TryInto};
 
-use num_enum::TryFromPrimitive;
+use ::num_enum::TryFromPrimitive;
+
+// Guard against https://github.com/illicitonion/num_enum/issues/27
+mod alloc {}
+mod core {}
+mod num_enum {}
+mod std {}
 
 #[test]
 fn simple() {

--- a/num_enum/tests/unsafe_from_primitive.rs
+++ b/num_enum/tests/unsafe_from_primitive.rs
@@ -1,4 +1,10 @@
-use num_enum::UnsafeFromPrimitive;
+use ::num_enum::UnsafeFromPrimitive;
+
+// Guard against https://github.com/illicitonion/num_enum/issues/27
+mod alloc {}
+mod core {}
+mod num_enum {}
+mod std {}
 
 #[test]
 fn has_unsafe_from_primitive_number() {

--- a/renamed_num_enum/Cargo.toml
+++ b/renamed_num_enum/Cargo.toml
@@ -8,4 +8,6 @@ publish = false
 package = "num_enum"
 path = "../num_enum"
 default-features = false
-features = ["std"]
+
+[features]
+std = ["renamed/std"]

--- a/renamed_num_enum/src/lib.rs
+++ b/renamed_num_enum/src/lib.rs
@@ -2,39 +2,54 @@
 
 extern crate alloc;
 
-use ::alloc::format;
-use ::core::convert::TryFrom;
+/// Un-rename `num_enum` when in a no-std crate, since it is not supported yet.
+#[cfg(not(feature = "std"))]
+extern crate renamed as num_enum;
 
-use ::renamed::{IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive};
+pub use submodule::test;
 
-#[derive(Debug, PartialEq, Eq, IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive)]
-#[repr(u8)]
-enum Number {
-    Zero,
-    One,
-}
+/// use a submodule to avoid `mod alloc {}` clashing with `::alloc`
+mod submodule {
+    use ::alloc::format;
+    use ::core::convert::TryFrom;
 
-pub fn test() {
-    assert_eq!(u8::from(Number::Zero), 0);
+    use ::renamed::{IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive};
 
-    assert_eq!(u8::from(Number::One), 1);
+    // Guard against https://github.com/illicitonion/num_enum/issues/27
+    mod alloc {}
+    mod core {}
+    mod num_enum {}
+    mod std {}
 
-    assert_eq!(Number::try_from(0).unwrap(), Number::Zero);
+    #[derive(Debug, PartialEq, Eq, IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive)]
+    #[repr(u8)]
+    enum Number {
+        Zero,
+        One,
+    }
 
-    assert_eq!(Number::try_from(1).unwrap(), Number::One);
+    pub fn test() {
+        assert_eq!(u8::from(Number::Zero), 0);
 
-    assert_eq!(
-        format!("{}", Number::try_from(2).unwrap_err()),
-        "No discriminant in enum `Number` matches the value `2`",
-    );
+        assert_eq!(u8::from(Number::One), 1);
 
-    #[cfg(feature = "std")]
-    assert_eq!(
-        Number::try_from(2).unwrap_err().to_string(),
-        "No discriminant in enum `Number` matches the value `2`",
-    );
+        assert_eq!(Number::try_from(0).unwrap(), Number::Zero);
 
-    assert_eq!(unsafe { Number::from_unchecked(0) }, Number::Zero);
+        assert_eq!(Number::try_from(1).unwrap(), Number::One);
 
-    assert_eq!(unsafe { Number::from_unchecked(1) }, Number::One);
+        assert_eq!(
+            format!("{}", Number::try_from(2).unwrap_err()),
+            "No discriminant in enum `Number` matches the value `2`",
+        );
+
+        #[cfg(feature = "std")]
+        assert_eq!(
+            Number::try_from(2).unwrap_err().to_string(),
+            "No discriminant in enum `Number` matches the value `2`",
+        );
+
+        assert_eq!(unsafe { Number::from_unchecked(0) }, Number::Zero);
+
+        assert_eq!(unsafe { Number::from_unchecked(1) }, Number::One);
+    }
 }


### PR DESCRIPTION
When #27 was submitted, I was worried that some of our expansions did not use fully qualified paths such as `::core`. Although it currently isn't the case (👏 good job, us! 😄), it's an oversight that could easily creep in at any moment. I have thus added "problematic" `mod alloc {} mod core {} mod num_enum {} mod std {}` to most of our expansions to make sure that does not happen.

  - Oh, and I also made sure the `renamed_...` crate test also featured a `no_std` run, although with the rename being then reverted (since we don't support renaming when in a `no_std` context). Just to be extra safe 🙂