### PR TITLE
Change generated constants name to uppercase

### DIFF
--- a/num_enum_derive/Cargo.toml
+++ b/num_enum_derive/Cargo.toml
@@ -35,3 +35,4 @@ proc-macro2 = "1"
 proc-macro-crate = { version = "0.1.4", optional = true }
 quote = "1"
 syn = { version = "1", features = ["parsing"] }
+convert_case = "0.4.0"

--- a/num_enum_derive/src/lib.rs
+++ b/num_enum_derive/src/lib.rs
@@ -9,6 +9,7 @@ use ::syn::{
     spanned::Spanned,
     Data, DeriveInput, Error, Expr, Ident, LitInt, LitStr, Meta, Result,
 };
+use convert_case::{Case, Casing};
 
 macro_rules! die {
     ($span:expr=>
@@ -178,9 +179,15 @@ impl EnumInfo {
         self.variants
             .iter()
             .map(|info| {
-                let indices = 0..(info.alternative_values.len() + 1);
+                let indices = 0..=(info.alternative_values.len());
                 indices
-                    .map(|index| format_ident!("{}__NUM_ENUM_{}__", info.ident, index))
+                    .map(|index| {
+                        format_ident!(
+                            "{}__NUM_ENUM_{}__",
+                            info.ident.to_string().to_case(Case::ScreamingSnake),
+                            index
+                        )
+                    })
                     .collect()
             })
             .collect()

--- a/num_enum_derive/src/lib.rs
+++ b/num_enum_derive/src/lib.rs
@@ -180,7 +180,7 @@ impl EnumInfo {
             .map(|info| {
                 let indices = 0..(info.alternative_values.len() + 1);
                 indices
-                    .map(|index| format_ident!("{}__num_enum_{}__", info.ident, index))
+                    .map(|index| format_ident!("{}__NUM_ENUM_{}__", info.ident, index))
                     .collect()
             })
             .collect()


### PR DESCRIPTION
Change name to uppercase to fix issue with [rust api guidelines](https://rust-lang.github.io/api-guidelines/naming.html) because rust-analyzer trigger to it even if there's no warnings.
![image](https://user-images.githubusercontent.com/33205215/115102770-dcc70880-9f55-11eb-8591-7615580d2124.png)
