### PR TITLE
Use extended_key_value_attributes for rustdoc

### DIFF
--- a/num_enum/src/lib.rs
+++ b/num_enum/src/lib.rs
@@ -1,8 +1,9 @@
-#![cfg_attr(feature = "external_doc", feature(external_doc))]
-#![cfg_attr(feature = "external_doc", doc(include = "../README.md"))]
+// Wrap this in two cfg_attrs so that it continues to parse pre-1.54.0.
+// See https://github.com/rust-lang/rust/issues/82768
+#![cfg_attr(feature = "external_doc", cfg_attr(all(), doc = include_str!("../README.md")))]
 #![cfg_attr(
     not(feature = "external_doc"),
-    doc = "See https://docs.rs/num_enum for more info about this crate."
+    doc = "See <https://docs.rs/num_enum> for more info about this crate."
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Hide this behind two layers of cfg_attr so that it still parses
pre-1.54.0.

Also, make the fallback text link be linkified.

When 1.54.0 hits stable I'll de-conditionalise this and make a 0.6.0
release with a bumped MSRV.