### PR TITLE
Remove derivative dependency

### DIFF
--- a/num_enum/Cargo.toml
+++ b/num_enum/Cargo.toml
@@ -29,7 +29,6 @@ travis-ci = { repository = "illicitonion/num_enum", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-derivative = { version = "2", features = ["use_core"] }
 num_enum_derive = { version = "0.5.5", path = "../num_enum_derive", default-features = false }
 
 [dev-dependencies]

--- a/num_enum/src/lib.rs
+++ b/num_enum/src/lib.rs
@@ -27,18 +27,31 @@ pub trait TryFromPrimitive: Sized {
     fn try_from_primitive(number: Self::Primitive) -> Result<Self, TryFromPrimitiveError<Self>>;
 }
 
-#[derive(::derivative::Derivative)]
-#[derivative( // use derivative to remove incorrect bound on `Enum` parameter. See https://github.com/rust-lang/rust/issues/26925
-    Debug(bound = ""),
-    Clone(bound = ""),
-    Copy(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = "")
-)]
 pub struct TryFromPrimitiveError<Enum: TryFromPrimitive> {
     pub number: Enum::Primitive,
 }
 
+impl<Enum: TryFromPrimitive> Copy for TryFromPrimitiveError<Enum> {}
+impl<Enum: TryFromPrimitive> Clone for TryFromPrimitiveError<Enum> {
+    fn clone(&self) -> Self {
+        TryFromPrimitiveError {
+            number: self.number,
+        }
+    }
+}
+impl<Enum: TryFromPrimitive> Eq for TryFromPrimitiveError<Enum> {}
+impl<Enum: TryFromPrimitive> PartialEq for TryFromPrimitiveError<Enum> {
+    fn eq(&self, other: &Self) -> bool {
+        self.number == other.number
+    }
+}
+impl<Enum: TryFromPrimitive> fmt::Debug for TryFromPrimitiveError<Enum> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("TryFromPrimitiveError")
+            .field("number", &self.number)
+            .finish()
+    }
+}
 impl<Enum: TryFromPrimitive> fmt::Display for TryFromPrimitiveError<Enum> {
     fn fmt(&self, stream: &'_ mut fmt::Formatter<'_>) -> fmt::Result {
         write!(


### PR DESCRIPTION
Derivative is only used to generate trait implementations for a single struct, to get around a standard library issue.  While manually expanding the trait implementations makes the code slightly longer, it allows removing a dependency and speeding up the build time of crates that depend on this.