### PR TITLE
Underline the correct alternative variant in case of error.

### DIFF
--- a/num_enum/tests/try_build/compile_fail/alternative_clashes_with_its_discriminant.rs
+++ b/num_enum/tests/try_build/compile_fail/alternative_clashes_with_its_discriminant.rs
@@ -1,0 +1,10 @@
+#[derive(num_enum::TryFromPrimitive)]
+#[repr(u8)]
+enum Numbers {
+    Zero = 0,
+    #[num_enum(alternatives = [3,1,4])]
+    One = 1,
+    Two = 2,
+}
+
+fn main() {}

--- a/num_enum/tests/try_build/compile_fail/alternative_clashes_with_its_discriminant.stderr
+++ b/num_enum/tests/try_build/compile_fail/alternative_clashes_with_its_discriminant.stderr
@@ -1,0 +1,5 @@
+error: '1' in the alternative values is already attributed as the discriminant of this variant
+ --> tests/try_build/compile_fail/alternative_clashes_with_its_discriminant.rs:5:34
+  |
+5 |     #[num_enum(alternatives = [3,1,4])]
+  |                                  ^

--- a/num_enum/tests/try_build/compile_fail/alternative_clashes_with_variant_out_of_order.rs
+++ b/num_enum/tests/try_build/compile_fail/alternative_clashes_with_variant_out_of_order.rs
@@ -1,0 +1,10 @@
+#[derive(num_enum::TryFromPrimitive)]
+#[repr(u8)]
+enum Numbers {
+    Zero = 0,
+    #[num_enum(alternatives = [5,7,0,3])]
+    One = 1,
+    Two = 2,
+}
+
+fn main() {}

--- a/num_enum/tests/try_build/compile_fail/alternative_clashes_with_variant_out_of_order.stderr
+++ b/num_enum/tests/try_build/compile_fail/alternative_clashes_with_variant_out_of_order.stderr
@@ -1,0 +1,5 @@
+error: '0' in the alternative values is already attributed to a previous variant
+ --> tests/try_build/compile_fail/alternative_clashes_with_variant_out_of_order.rs:5:36
+  |
+5 |     #[num_enum(alternatives = [5,7,0,3])]
+  |                                    ^


### PR DESCRIPTION
Fix #97.

Small PR to underline the correct alternative variant when they are not written in order.

## Before:
![image](https://user-images.githubusercontent.com/29143941/212555608-6d1b75b5-b29c-4b8b-8cb5-3eee07bc74c9.png)

![image](https://user-images.githubusercontent.com/29143941/212555617-f36d9bca-eb1d-4467-a51e-49d95670c224.png)

## After:
![image](https://user-images.githubusercontent.com/29143941/212555588-039922e1-3146-485e-bf75-221155aae6c6.png)


![image](https://user-images.githubusercontent.com/29143941/212555516-a9e34a22-3bb2-4a92-85fe-c95ff735304d.png)

