### PR TITLE
fix(#102): Fixed shift error on >64 bit enums

### DIFF
--- a/num_enum/tests/from_primitive.rs
+++ b/num_enum/tests/from_primitive.rs
@@ -9,6 +9,26 @@ mod num_enum {}
 mod std {}
 
 #[test]
+fn has_from_primitive_number_u64() {
+    #[derive(Debug, Eq, PartialEq, FromPrimitive)]
+    #[repr(u64)]
+    enum Enum {
+        Zero = 0,
+        #[num_enum(default)]
+        NonZero = 1,
+    }
+
+    let zero = Enum::from_primitive(0_u64);
+    assert_eq!(zero, Enum::Zero);
+
+    let one = Enum::from_primitive(1_u64);
+    assert_eq!(one, Enum::NonZero);
+
+    let two = Enum::from_primitive(2_u64);
+    assert_eq!(two, Enum::NonZero);
+}
+
+#[test]
 fn has_from_primitive_number() {
     #[derive(Debug, Eq, PartialEq, FromPrimitive)]
     #[repr(u8)]

--- a/num_enum_derive/src/lib.rs
+++ b/num_enum_derive/src/lib.rs
@@ -209,8 +209,9 @@ impl EnumInfo {
                 .strip_prefix('i')
                 .or_else(|| repr_str.strip_prefix('u'));
             if let Some(suffix) = suffix {
-                if let Ok(bits) = suffix.parse::<u8>() {
-                    return Ok(1 << bits == self.variants.len());
+                if let Ok(bits) = suffix.parse::<u32>() {
+                    let variants = 1usize.checked_shl(bits);
+                    return Ok(variants.map_or(false, |v| v == self.variants.len()))
                 }
             }
         }

--- a/num_enum_derive/src/lib.rs
+++ b/num_enum_derive/src/lib.rs
@@ -211,7 +211,7 @@ impl EnumInfo {
             if let Some(suffix) = suffix {
                 if let Ok(bits) = suffix.parse::<u32>() {
                     let variants = 1usize.checked_shl(bits);
-                    return Ok(variants.map_or(false, |v| v == self.variants.len()))
+                    return Ok(variants.map_or(false, |v| v == self.variants.len()));
                 }
             }
         }


### PR DESCRIPTION
Large enums realistically will never be naturally exhaustive due to their size. The shift is now done as a checked shift and when the shift fails it will default to not naturally exhaustive, requiring the default attribute, even if it were exhaustive. (I want to meet the person who manages to write down 2^64 enum values or more)