### PR TITLE
TryFromPrimitive ignores default attributes

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -28,7 +28,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "num_enum_derive",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.6.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/README.md
+++ b/README.md
@@ -127,15 +127,15 @@ Default variant
 
 Sometimes it is desirable to have an `Other` variant in an enum that acts as a kind of a wildcard matching all the value not yet covered by other variants.
 
-The `#[num_enum(default)]` attribute allows you to mark variant as the default.
+The `#[num_enum(default)]` attribute (or the stdlib `#[default]` attribute) allows you to mark variant as the default.
 
 (The behavior of `IntoPrimitive` is unaffected by this attribute, it will always return the canonical value.)
 
 ```rust
-use num_enum::TryFromPrimitive;
+use num_enum::FromPrimitive;
 use std::convert::TryFrom;
 
-#[derive(Debug, Eq, PartialEq, TryFromPrimitive)]
+#[derive(Debug, Eq, PartialEq, FromPrimitive)]
 #[repr(u8)]
 enum Number {
     Zero = 0,
@@ -144,16 +144,18 @@ enum Number {
 }
 
 fn main() {
-    let zero = Number::try_from(0u8);
-    assert_eq!(zero, Ok(Number::Zero));
+    let zero = Number::from(0u8);
+    assert_eq!(zero, Number::Zero);
 
-    let one = Number::try_from(1u8);
-    assert_eq!(one, Ok(Number::NonZero));
+    let one = Number::from(1u8);
+    assert_eq!(one, Number::NonZero);
 
-    let two = Number::try_from(2u8);
-    assert_eq!(two, Ok(Number::NonZero));
+    let two = Number::from(2u8);
+    assert_eq!(two, Number::NonZero);
 }
 ```
+
+Only `FromPrimitive` pays attention to `default` attributes, `TryFromPrimitive` ignores them.
 
 Safely turning a primitive into an exhaustive enum with from_primitive
 -------------------------------------------------------------

--- a/num_enum/Cargo.toml
+++ b/num_enum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num_enum"
-version = "0.5.11"  # Keep in sync with num_enum_derive, the the dependency on it below.
+version = "0.6.0"  # Keep in sync with num_enum_derive, the the dependency on it below.
 authors = [
   "Daniel Wagner-Hall <dawagner@gmail.com>",
   "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
@@ -29,7 +29,7 @@ travis-ci = { repository = "illicitonion/num_enum", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-num_enum_derive = { version = "0.5.11", path = "../num_enum_derive", default-features = false }
+num_enum_derive = { version = "0.6.0", path = "../num_enum_derive", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.14"

--- a/num_enum/src/lib.rs
+++ b/num_enum/src/lib.rs
@@ -65,3 +65,13 @@ impl<Enum: TryFromPrimitive> fmt::Display for TryFromPrimitiveError<Enum> {
 
 #[cfg(feature = "std")]
 impl<Enum: TryFromPrimitive> ::std::error::Error for TryFromPrimitiveError<Enum> {}
+
+// This trait exists to try to give a more clear error message when someone attempts to derive both FromPrimitive and TryFromPrimitive.
+// This isn't allowed because both end up creating a `TryFrom<primitive>` implementation.
+// TryFromPrimitive explicitly implements TryFrom<primitive> with Error=TryFromPrimitiveError, which conflicts with:
+// FromPrimitive explicitly implements From<primitive> which has a blanket implementation of TryFrom<primitive> with Error=Infallible.
+//
+// This is a private implementation detail of the num_enum crate which should not be depended on externally.
+// It is subject to change in any release regardless of semver.
+#[doc(hidden)]
+pub trait CannotDeriveBothFromPrimitiveAndTryFromPrimitive {}

--- a/num_enum/tests/from_primitive.rs
+++ b/num_enum/tests/from_primitive.rs
@@ -1,6 +1,4 @@
-use ::std::convert::TryFrom;
-
-use ::num_enum::{FromPrimitive, TryFromPrimitive};
+use ::num_enum::FromPrimitive;
 
 // Guard against https://github.com/illicitonion/num_enum/issues/27
 mod alloc {}
@@ -89,11 +87,11 @@ fn from_primitive_number() {
     let from = Enum::from(0_u8);
     assert_eq!(from, Enum::Whatever);
 
-    let try_from_primitive = Enum::try_from_primitive(0_u8);
-    assert_eq!(try_from_primitive, Ok(Enum::Whatever));
+    let from_primitive = Enum::from_primitive(1_u8);
+    assert_eq!(from_primitive, Enum::Whatever);
 
-    let try_from = Enum::try_from(0_u8);
-    assert_eq!(try_from, Ok(Enum::Whatever));
+    let from = Enum::from(1_u8);
+    assert_eq!(from, Enum::Whatever);
 }
 
 #[test]

--- a/num_enum/tests/try_build/compile_fail/conflicting_derive.stderr
+++ b/num_enum/tests/try_build/compile_fail/conflicting_derive.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `TryFromPrimitive` for type `Numbers`
+error[E0119]: conflicting implementations of trait `CannotDeriveBothFromPrimitiveAndTryFromPrimitive` for type `Numbers`
  --> tests/try_build/compile_fail/conflicting_derive.rs:1:35
   |
 1 | #[derive(num_enum::FromPrimitive, num_enum::TryFromPrimitive)]

--- a/num_enum/tests/try_from_primitive.rs
+++ b/num_enum/tests/try_from_primitive.rs
@@ -440,7 +440,10 @@ fn default_value() {
     assert_eq!(two, Ok(Enum::Other));
 
     let max_value: Result<Enum, _> = u8::max_value().try_into();
-    assert_eq!(max_value, Ok(Enum::Other));
+    assert_eq!(
+        max_value.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `255`"
+    );
 }
 
 #[test]
@@ -472,7 +475,10 @@ fn alternative_values_and_default_value() {
     assert_eq!(four, Ok(Enum::Four));
 
     let five: Result<Enum, _> = 5u8.try_into();
-    assert_eq!(five, Ok(Enum::Zero));
+    assert_eq!(
+        five.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `5`"
+    );
 }
 
 #[test]

--- a/num_enum_derive/Cargo.toml
+++ b/num_enum_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num_enum_derive"
-version = "0.5.11"  # Keep in sync with num_enum.
+version = "0.6.0"  # Keep in sync with num_enum.
 authors = [
   "Daniel Wagner-Hall <dawagner@gmail.com>",
   "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",


### PR DESCRIPTION
If exhaustive behaviour is desired, FromPrimitive should be derived
instead.

Because these traits are exclusive, there's no room for ambiguity here -
either TryFromPrimitive is derived and defaults are ignored, or
FromPrimitive is derived and defaults are paid attention to.

This is, however, a breaking change, as it changes the implementation of
TryFromPrimitive significantly.

Fixes https://github.com/illicitonion/num_enum/issues/75
Fixes https://github.com/illicitonion/num_enum/issues/31