### PR TITLE
Update syn to v2

### DIFF
--- a/.github/workflows/msrv-build.yml
+++ b/.github/workflows/msrv-build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.54.0
+          toolchain: 1.56.0
           target: thumbv6m-none-eabi
       - name: Use MSRV Cargo.lock
         run: cp Cargo.lock.msrv Cargo.lock
@@ -24,10 +24,10 @@ jobs:
         with:
           command: build
           args: --all --locked
-          toolchain: 1.54.0
+          toolchain: 1.56.0
       - name: Build no-std with MSRV
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --manifest-path=num_enum/Cargo.toml --target thumbv6m-none-eabi --no-default-features --locked
-          toolchain: 1.54.0
+          toolchain: 1.56.0

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -44,7 +44,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -59,18 +59,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -120,7 +120,7 @@ checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -162,6 +162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,7 +198,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -212,6 +223,12 @@ dependencies = [
  "termcolor",
  "toml",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-xid"

--- a/num_enum_derive/Cargo.toml
+++ b/num_enum_derive/Cargo.toml
@@ -34,4 +34,4 @@ features = ["external_doc"]
 proc-macro2 = "1"
 proc-macro-crate = { version = "1", optional = true }
 quote = "1"
-syn = { version = "1.0.15", features = ["parsing"] }
+syn = { version = "2.0.10", features = ["parsing"] }


### PR DESCRIPTION
This should deal with all of the breakages from updating to `syn` v2

This update would also require an MSRV bump, since it looks like the current MSRV is 1.54 while `syn` bumped up to 1.56 (2021 edition)