### PR TITLE
Fix is_naturally_exhaustive test for usize/isize.

### DIFF
--- a/num_enum/tests/from_primitive.rs
+++ b/num_enum/tests/from_primitive.rs
@@ -7,26 +7,24 @@ mod num_enum {}
 mod std {}
 
 macro_rules! has_from_primitive_number {
-    ( $type:ty ) => {
-        {
-            #[derive(Debug, Eq, PartialEq, FromPrimitive)]
-            #[repr($type)]
-            enum Enum {
-                Zero = 0,
-                #[num_enum(default)]
-                NonZero = 1,
-            }
-
-            let zero = Enum::from_primitive(0 as $type);
-            assert_eq!(zero, Enum::Zero);
-
-            let one = Enum::from_primitive(1 as $type);
-            assert_eq!(one, Enum::NonZero);
-
-            let two = Enum::from_primitive(2 as $type);
-            assert_eq!(two, Enum::NonZero);
+    ( $type:ty ) => {{
+        #[derive(Debug, Eq, PartialEq, FromPrimitive)]
+        #[repr($type)]
+        enum Enum {
+            Zero = 0,
+            #[num_enum(default)]
+            NonZero = 1,
         }
-    };
+
+        let zero = Enum::from_primitive(0 as $type);
+        assert_eq!(zero, Enum::Zero);
+
+        let one = Enum::from_primitive(1 as $type);
+        assert_eq!(one, Enum::NonZero);
+
+        let two = Enum::from_primitive(2 as $type);
+        assert_eq!(two, Enum::NonZero);
+    }};
 }
 
 #[test]

--- a/num_enum/tests/from_primitive.rs
+++ b/num_enum/tests/from_primitive.rs
@@ -6,44 +6,44 @@ mod core {}
 mod num_enum {}
 mod std {}
 
-#[test]
-fn has_from_primitive_number_u64() {
-    #[derive(Debug, Eq, PartialEq, FromPrimitive)]
-    #[repr(u64)]
-    enum Enum {
-        Zero = 0,
-        #[num_enum(default)]
-        NonZero = 1,
-    }
+macro_rules! has_from_primitive_number {
+    ( $type:ty ) => {
+        {
+            #[derive(Debug, Eq, PartialEq, FromPrimitive)]
+            #[repr($type)]
+            enum Enum {
+                Zero = 0,
+                #[num_enum(default)]
+                NonZero = 1,
+            }
 
-    let zero = Enum::from_primitive(0_u64);
-    assert_eq!(zero, Enum::Zero);
+            let zero = Enum::from_primitive(0 as $type);
+            assert_eq!(zero, Enum::Zero);
 
-    let one = Enum::from_primitive(1_u64);
-    assert_eq!(one, Enum::NonZero);
+            let one = Enum::from_primitive(1 as $type);
+            assert_eq!(one, Enum::NonZero);
 
-    let two = Enum::from_primitive(2_u64);
-    assert_eq!(two, Enum::NonZero);
+            let two = Enum::from_primitive(2 as $type);
+            assert_eq!(two, Enum::NonZero);
+        }
+    };
 }
 
 #[test]
 fn has_from_primitive_number() {
-    #[derive(Debug, Eq, PartialEq, FromPrimitive)]
-    #[repr(u8)]
-    enum Enum {
-        Zero = 0,
-        #[num_enum(default)]
-        NonZero = 1,
-    }
-
-    let zero = Enum::from_primitive(0_u8);
-    assert_eq!(zero, Enum::Zero);
-
-    let one = Enum::from_primitive(1_u8);
-    assert_eq!(one, Enum::NonZero);
-
-    let two = Enum::from_primitive(2_u8);
-    assert_eq!(two, Enum::NonZero);
+    has_from_primitive_number!(u8);
+    has_from_primitive_number!(u16);
+    has_from_primitive_number!(u32);
+    has_from_primitive_number!(u64);
+    has_from_primitive_number!(usize);
+    has_from_primitive_number!(i8);
+    has_from_primitive_number!(i16);
+    has_from_primitive_number!(i32);
+    has_from_primitive_number!(i64);
+    has_from_primitive_number!(isize);
+    // repr with 128-bit type is unstable
+    // has_from_primitive_number!(u128);
+    // has_from_primitive_number!(i128);
 }
 
 #[test]

--- a/num_enum_derive/src/lib.rs
+++ b/num_enum_derive/src/lib.rs
@@ -237,7 +237,9 @@ impl EnumInfo {
                 .strip_prefix('i')
                 .or_else(|| repr_str.strip_prefix('u'));
             if let Some(suffix) = suffix {
-                if let Ok(bits) = suffix.parse::<u32>() {
+                if suffix == "size" {
+                    return Ok(false);
+                } else if let Ok(bits) = suffix.parse::<u32>() {
                     let variants = 1usize.checked_shl(bits);
                     return Ok(variants.map_or(false, |v| {
                         v == self


### PR DESCRIPTION
Always return false in those cases (as is the case for u32, i32, u64, and i64).

Without this, `FromPrimitive` is not usable with `repr(usize)`.