### PR TITLE
Update `proc-macro-crate` to 2.0

### DIFF
--- a/num_enum_derive/Cargo.toml
+++ b/num_enum_derive/Cargo.toml
@@ -33,7 +33,7 @@ features = ["external_doc"]
 
 [dependencies]
 proc-macro2 = "1.0.60"
-proc-macro-crate = { version = "1", optional = true }
+proc-macro-crate = { version = "2.0.0", optional = true }
 quote = "1"
 syn = { version = "2", features = ["parsing"] }
 


### PR DESCRIPTION
This indirectly bumps `toml_edit` to v0.20.2.

Personally, this would be useful for reducing the number of versions of `toml_edit` we are building in our project.