### PR TITLE
ci: Update to `actions/checkout@v4`.

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Fetch toolchain
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Fetch toolchain
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/msrv-build.yml
+++ b/.github/workflows/msrv-build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Fetch toolchain
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,7 +15,7 @@ jobs:
         toolchain: [stable, beta, nightly]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Fetch toolchain
         uses: dtolnay/rust-toolchain@v1
         with:


### PR DESCRIPTION
This moves to the latest version (as of now).