### PR TITLE
feature: const variants of into, from, try_from, and default

### DIFF
--- a/num_enum/src/lib.rs
+++ b/num_enum/src/lib.rs
@@ -8,7 +8,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use ::num_enum_derive::{
-    Default, FromPrimitive, IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive,
+    ConstIntoPrimitive, Default, FromPrimitive, IntoPrimitive, TryFromPrimitive,
+    UnsafeFromPrimitive,
 };
 
 use ::core::fmt;

--- a/num_enum/src/lib.rs
+++ b/num_enum/src/lib.rs
@@ -8,8 +8,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use ::num_enum_derive::{
-    ConstFromPrimitive, ConstIntoPrimitive, ConstTryFromPrimitive, Default, FromPrimitive,
-    IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive,
+    ConstDefault, ConstFromPrimitive, ConstIntoPrimitive, ConstTryFromPrimitive, Default,
+    FromPrimitive, IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive,
 };
 
 use ::core::fmt;

--- a/num_enum/src/lib.rs
+++ b/num_enum/src/lib.rs
@@ -8,8 +8,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use ::num_enum_derive::{
-    ConstFromPrimitive, ConstIntoPrimitive, Default, FromPrimitive, IntoPrimitive,
-    TryFromPrimitive, UnsafeFromPrimitive,
+    ConstFromPrimitive, ConstIntoPrimitive, ConstTryFromPrimitive, Default, FromPrimitive,
+    IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive,
 };
 
 use ::core::fmt;
@@ -27,6 +27,13 @@ pub trait TryFromPrimitive: Sized {
     const NAME: &'static str;
 
     fn try_from_primitive(number: Self::Primitive) -> Result<Self, Self::Error>;
+}
+
+pub trait ConstTryFromPrimitive: Sized {
+    type Primitive: Copy + Eq + fmt::Debug;
+    type Error;
+
+    const NAME: &'static str;
 }
 
 pub trait UnsafeFromPrimitive: Sized {
@@ -85,6 +92,38 @@ impl<Enum: TryFromPrimitive> fmt::Display for TryFromPrimitiveError<Enum> {
 #[cfg(feature = "std")]
 impl<Enum: TryFromPrimitive> ::std::error::Error for TryFromPrimitiveError<Enum> {}
 
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct ConstTryFromPrimitiveError<Enum: ConstTryFromPrimitive> {
+    pub number: Enum::Primitive,
+}
+
+impl<Enum: ConstTryFromPrimitive> ConstTryFromPrimitiveError<Enum> {
+    pub const fn new(number: Enum::Primitive) -> Self {
+        Self { number }
+    }
+}
+
+impl<Enum: ConstTryFromPrimitive> fmt::Debug for ConstTryFromPrimitiveError<Enum> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("ConstTryFromPrimitiveError")
+            .field("number", &self.number)
+            .finish()
+    }
+}
+impl<Enum: ConstTryFromPrimitive> fmt::Display for ConstTryFromPrimitiveError<Enum> {
+    fn fmt(&self, stream: &'_ mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            stream,
+            "No discriminant in enum `{name}` matches the value `{input:?}`",
+            name = Enum::NAME,
+            input = self.number,
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl<Enum: ConstTryFromPrimitive> ::std::error::Error for ConstTryFromPrimitiveError<Enum> {}
+
 // This trait exists to try to give a more clear error message when someone attempts to derive both FromPrimitive and TryFromPrimitive.
 // This isn't allowed because both end up creating a `TryFrom<primitive>` implementation.
 // TryFromPrimitive explicitly implements TryFrom<primitive> with Error=TryFromPrimitiveError, which conflicts with:
@@ -94,3 +133,7 @@ impl<Enum: TryFromPrimitive> ::std::error::Error for TryFromPrimitiveError<Enum>
 // It is subject to change in any release regardless of semver.
 #[doc(hidden)]
 pub trait CannotDeriveBothFromPrimitiveAndTryFromPrimitive {}
+
+// Similar, for const primitive coercion methods.
+#[doc(hidden)]
+pub trait CannotDeriveBothConstFromPrimitiveAndConstTryFromPrimitive {}

--- a/num_enum/src/lib.rs
+++ b/num_enum/src/lib.rs
@@ -8,8 +8,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use ::num_enum_derive::{
-    ConstIntoPrimitive, Default, FromPrimitive, IntoPrimitive, TryFromPrimitive,
-    UnsafeFromPrimitive,
+    ConstFromPrimitive, ConstIntoPrimitive, Default, FromPrimitive, IntoPrimitive,
+    TryFromPrimitive, UnsafeFromPrimitive,
 };
 
 use ::core::fmt;

--- a/num_enum/tests/const_default.rs
+++ b/num_enum/tests/const_default.rs
@@ -1,0 +1,37 @@
+#![allow(non_upper_case_globals)]
+
+// Guard against https://github.com/illicitonion/num_enum/issues/27
+mod alloc {}
+mod core {}
+mod num_enum {}
+mod std {}
+
+#[test]
+fn default() {
+    #[derive(Debug, Eq, PartialEq, ::num_enum::ConstDefault)]
+    #[repr(u8)]
+    enum Enum {
+        #[allow(unused)]
+        Zero = 0,
+        #[num_enum(default)]
+        NonZero = 1,
+    }
+
+    const nz: Enum = Enum::const_default();
+    assert_eq!(Enum::NonZero, nz);
+}
+
+#[test]
+fn default_standard_default_attribute() {
+    #[derive(Debug, Eq, PartialEq, ::num_enum::ConstDefault)]
+    #[repr(u8)]
+    enum Enum {
+        #[allow(unused)]
+        Zero = 0,
+        #[default]
+        NonZero = 1,
+    }
+
+    const nz: Enum = Enum::const_default();
+    assert_eq!(Enum::NonZero, nz);
+}

--- a/num_enum/tests/const_from_primitive.rs
+++ b/num_enum/tests/const_from_primitive.rs
@@ -1,0 +1,116 @@
+#![allow(non_upper_case_globals)]
+
+use ::num_enum::ConstFromPrimitive;
+
+// Guard against https://github.com/illicitonion/num_enum/issues/27
+mod alloc {}
+mod core {}
+mod num_enum {}
+mod std {}
+
+macro_rules! has_from_primitive_number {
+    ( $type:ty ) => {
+        paste::paste! {
+            #[test]
+            fn [<has_from_primitive_number_ $type>]() {
+                #[derive(Debug, Eq, PartialEq, ConstFromPrimitive)]
+                #[repr($type)]
+                enum Enum {
+                    Zero = 0,
+                    #[num_enum(default)]
+                    NonZero = 1,
+                }
+
+                const zero: Enum = Enum::const_from(0 as $type);
+                assert_eq!(zero, Enum::Zero);
+
+                const one: Enum = Enum::const_from(1 as $type);
+                assert_eq!(one, Enum::NonZero);
+
+                const two: Enum = Enum::const_from(2 as $type);
+                assert_eq!(two, Enum::NonZero);
+            }
+        }
+    };
+}
+
+has_from_primitive_number!(u8);
+has_from_primitive_number!(u16);
+has_from_primitive_number!(u32);
+has_from_primitive_number!(u64);
+has_from_primitive_number!(usize);
+has_from_primitive_number!(i8);
+has_from_primitive_number!(i16);
+has_from_primitive_number!(i32);
+has_from_primitive_number!(i64);
+has_from_primitive_number!(isize);
+// repr with 128-bit type is unstable
+// has_from_primitive_number!(u128);
+// has_from_primitive_number!(i128);
+
+#[test]
+fn has_from_primitive_number_standard_default_attribute() {
+    #[derive(Debug, Eq, PartialEq, ConstFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero = 0,
+        #[default]
+        NonZero = 1,
+    }
+
+    const zero: Enum = Enum::const_from(0_u8);
+    assert_eq!(zero, Enum::Zero);
+
+    const one: Enum = Enum::const_from(1_u8);
+    assert_eq!(one, Enum::NonZero);
+
+    const two: Enum = Enum::const_from(2_u8);
+    assert_eq!(two, Enum::NonZero);
+}
+
+#[test]
+fn from_primitive_number_catch_all() {
+    #[derive(Debug, Eq, PartialEq, ConstFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero = 0,
+        #[num_enum(catch_all)]
+        NonZero(u8),
+    }
+
+    const zero: Enum = Enum::const_from(0_u8);
+    assert_eq!(zero, Enum::Zero);
+
+    const one: Enum = Enum::const_from(1_u8);
+    assert_eq!(one, Enum::NonZero(1_u8));
+
+    const two: Enum = Enum::const_from(2_u8);
+    assert_eq!(two, Enum::NonZero(2_u8));
+}
+
+#[cfg(feature = "complex-expressions")]
+#[test]
+fn from_primitive_number_with_inclusive_range() {
+    #[derive(Debug, Eq, PartialEq, ConstFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero = 0,
+        #[num_enum(alternatives = [2..=255])]
+        NonZero,
+    }
+
+    const zero: Enum = Enum::const_from(0_u8);
+    assert_eq!(zero, Enum::Zero);
+
+    const one: Enum = Enum::const_from(1_u8);
+    assert_eq!(one, Enum::NonZero);
+
+    const two: Enum = Enum::const_from(2_u8);
+    assert_eq!(two, Enum::NonZero);
+
+    const three: Enum = Enum::const_from(3_u8);
+    assert_eq!(three, Enum::NonZero);
+
+    const twofivefive: Enum = Enum::const_from(255_u8);
+    assert_eq!(twofivefive, Enum::NonZero);
+}

--- a/num_enum/tests/const_into_primitive.rs
+++ b/num_enum/tests/const_into_primitive.rs
@@ -1,0 +1,49 @@
+#![allow(non_upper_case_globals)]
+
+use ::num_enum::ConstIntoPrimitive;
+
+// Guard against https://github.com/illicitonion/num_enum/issues/27
+mod alloc {}
+mod core {}
+mod num_enum {}
+mod std {}
+
+#[derive(ConstIntoPrimitive)]
+#[repr(u8)]
+enum Enum {
+    Zero,
+    One,
+    Two,
+}
+
+#[test]
+fn simple() {
+    const zero: u8 = Enum::Zero.const_into();
+    assert_eq!(zero, 0u8);
+
+    const one: u8 = Enum::One.const_into();
+    assert_eq!(one, 1u8);
+
+    const two: u8 = Enum::Two.const_into();
+    assert_eq!(two, 2u8);
+}
+
+#[test]
+fn catch_all() {
+    #[derive(Debug, Eq, PartialEq, ConstIntoPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero = 0,
+        #[num_enum(catch_all)]
+        NonZero(u8),
+    }
+
+    const zero: u8 = Enum::Zero.const_into();
+    assert_eq!(zero, 0u8);
+
+    const one: u8 = Enum::NonZero(1u8).const_into();
+    assert_eq!(one, 1u8);
+
+    const two: u8 = Enum::NonZero(2u8).const_into();
+    assert_eq!(two, 2u8);
+}

--- a/num_enum/tests/const_try_from_primitive.rs
+++ b/num_enum/tests/const_try_from_primitive.rs
@@ -1,0 +1,553 @@
+#![allow(non_upper_case_globals)]
+
+use ::num_enum::{ConstTryFromPrimitive, ConstTryFromPrimitiveError};
+
+// Guard against https://github.com/illicitonion/num_enum/issues/27
+mod alloc {}
+mod core {}
+mod num_enum {}
+mod std {}
+
+#[test]
+fn simple() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero,
+        One,
+        Two,
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const three: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(3u8);
+    assert_eq!(
+        three.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `3`"
+    );
+}
+
+#[test]
+fn even() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero = 0,
+        Two = 2,
+        Four = 4,
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(
+        one.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `1`"
+    );
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(two, Ok(Enum::Two));
+
+    const three: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(3u8);
+    assert_eq!(
+        three.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `3`"
+    );
+
+    const four: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(4u8);
+    assert_eq!(four, Ok(Enum::Four));
+}
+
+#[test]
+fn skipped_value() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero,
+        One,
+        Three = 3,
+        Four,
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(
+        two.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `2`"
+    );
+
+    const three: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(3u8);
+    assert_eq!(three, Ok(Enum::Three));
+
+    const four: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(4u8);
+    assert_eq!(four, Ok(Enum::Four));
+}
+
+#[test]
+fn wrong_order() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Four = 4,
+        Three = 3,
+        Zero = 0,
+        One, // Zero + 1
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(
+        two.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `2`"
+    );
+
+    const three: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(3u8);
+    assert_eq!(three, Ok(Enum::Three));
+
+    const four: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(4u8);
+    assert_eq!(four, Ok(Enum::Four));
+}
+
+#[test]
+fn negative_values() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(i8)]
+    enum Enum {
+        MinusTwo = -2,
+        MinusOne = -1,
+        Zero = 0,
+        One = 1,
+        Two = 2,
+    }
+
+    const minus_two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(-2i8);
+    assert_eq!(minus_two, Ok(Enum::MinusTwo));
+
+    const minus_one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(-1i8);
+    assert_eq!(minus_one, Ok(Enum::MinusOne));
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0i8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1i8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2i8);
+    assert_eq!(two, Ok(Enum::Two));
+}
+
+#[test]
+fn discriminant_expressions() {
+    const ONE: u8 = 1;
+
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero,
+        One = ONE,
+        Two,
+        Four = 4u8,
+        Five,
+        Six = ONE + ONE + 2u8 + 2,
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(two, Ok(Enum::Two));
+
+    const three: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(3u8);
+    assert_eq!(
+        three.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `3`",
+    );
+
+    const four: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(4u8);
+    assert_eq!(four, Ok(Enum::Four));
+
+    const five: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(5u8);
+    assert_eq!(five, Ok(Enum::Five));
+
+    const six: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(6u8);
+    assert_eq!(six, Ok(Enum::Six));
+}
+
+#[cfg(feature = "complex-expressions")]
+mod complex {
+    use num_enum::ConstTryFromPrimitive;
+    use std::convert::TryInto;
+
+    const ONE: u8 = 1;
+
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero,
+        One = ONE,
+        Two,
+        Four = 4u8,
+        Five,
+        Six = ONE + ONE + 2u8 + 2,
+        Seven = (7, 2).0,
+    }
+
+    #[test]
+    fn different_values() {
+        const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+        assert_eq!(zero, Ok(Enum::Zero));
+
+        const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+        assert_eq!(one, Ok(Enum::One));
+
+        const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+        assert_eq!(two, Ok(Enum::Two));
+
+        const three: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(3u8);
+        assert_eq!(
+            three.unwrap_err().to_string(),
+            "No discriminant in enum `Enum` matches the value `3`",
+        );
+
+        const four: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(4u8);
+        assert_eq!(four, Ok(Enum::Four));
+
+        const five: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(5u8);
+        assert_eq!(five, Ok(Enum::Five));
+
+        const six: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(6u8);
+        assert_eq!(six, Ok(Enum::Six));
+
+        const seven: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(7u8);
+        assert_eq!(seven, Ok(Enum::Seven));
+    }
+
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum EnumWithExclusiveRange {
+        Zero = 0,
+        #[num_enum(alternatives = [2..4])]
+        OneOrTwoOrThree,
+    }
+
+    #[test]
+    fn different_values_with_exclusive_range() {
+        const zero: Result<EnumWithExclusiveRange, _> = Enum::const_try_from(0u8);
+        assert_eq!(zero, Ok(EnumWithExclusiveRange::Zero));
+
+        const one: Result<EnumWithExclusiveRange, _> = Enum::const_try_from(1u8);
+        assert_eq!(one, Ok(EnumWithExclusiveRange::OneOrTwoOrThree));
+
+        const two: Result<EnumWithExclusiveRange, _> = Enum::const_try_from(2u8);
+        assert_eq!(two, Ok(EnumWithExclusiveRange::OneOrTwoOrThree));
+
+        const three: Result<EnumWithExclusiveRange, _> = Enum::const_try_from(3u8);
+        assert_eq!(three, Ok(EnumWithExclusiveRange::OneOrTwoOrThree));
+
+        const four: Result<EnumWithExclusiveRange, _> = Enum::const_try_from(4u8);
+        assert_eq!(
+            four.unwrap_err().to_string(),
+            "No discriminant in enum `EnumWithExclusiveRange` matches the value `4`",
+        );
+    }
+
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum EnumWithInclusiveRange {
+        Zero = 0,
+        #[num_enum(alternatives = [2..=3])]
+        OneOrTwoOrThree,
+    }
+
+    #[test]
+    fn different_values_with_inclusive_range() {
+        const zero: Result<EnumWithInclusiveRange, _> = Enum::const_try_from(0u8);
+        assert_eq!(zero, Ok(EnumWithInclusiveRange::Zero));
+
+        const one: Result<EnumWithInclusiveRange, _> = Enum::const_try_from(1u8);
+        assert_eq!(one, Ok(EnumWithInclusiveRange::OneOrTwoOrThree));
+
+        const two: Result<EnumWithInclusiveRange, _> = Enum::const_try_from(2u8);
+        assert_eq!(two, Ok(EnumWithInclusiveRange::OneOrTwoOrThree));
+
+        const three: Result<EnumWithInclusiveRange, _> = Enum::const_try_from(3u8);
+        assert_eq!(three, Ok(EnumWithInclusiveRange::OneOrTwoOrThree));
+
+        const four: Result<EnumWithInclusiveRange, _> = Enum::const_try_from(4u8);
+        assert_eq!(
+            four.unwrap_err().to_string(),
+            "No discriminant in enum `EnumWithInclusiveRange` matches the value `4`",
+        );
+    }
+}
+
+#[test]
+fn missing_trailing_comma() {
+    #[rustfmt::skip]
+#[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+#[repr(u8)]
+enum Enum {
+    Zero,
+    One
+}
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(
+        two.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `2`"
+    );
+}
+
+#[test]
+fn ignores_extra_attributes() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[allow(unused)]
+    #[repr(u8)]
+    enum Enum {
+        Zero,
+        #[allow(unused)]
+        One,
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(
+        two.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `2`"
+    );
+}
+
+#[test]
+fn visibility_is_fine() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    pub(crate) enum Enum {
+        Zero,
+        One,
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(
+        two.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `2`"
+    );
+}
+
+#[test]
+fn error_variant_is_allowed() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    pub enum Enum {
+        Ok,
+        Error,
+    }
+
+    const ok: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(ok, Ok(Enum::Ok));
+
+    const err: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(err, Ok(Enum::Error));
+
+    const unknown: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(
+        unknown.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `2`"
+    );
+}
+
+#[test]
+fn alternative_values() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(i8)]
+    enum Enum {
+        Zero = 0,
+        #[num_enum(alternatives = [-1, 2, 3])]
+        OneTwoThreeOrMinusOne = 1,
+    }
+
+    const minus_one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(-1i8);
+    assert_eq!(minus_one, Ok(Enum::OneTwoThreeOrMinusOne));
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0i8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1i8);
+    assert_eq!(one, Ok(Enum::OneTwoThreeOrMinusOne));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2i8);
+    assert_eq!(two, Ok(Enum::OneTwoThreeOrMinusOne));
+
+    const three: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(3i8);
+    assert_eq!(three, Ok(Enum::OneTwoThreeOrMinusOne));
+
+    const four: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(4i8);
+    assert_eq!(
+        four.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `4`"
+    );
+}
+
+#[test]
+fn default_value() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        Zero = 0,
+        One = 1,
+        #[num_enum(default)]
+        Other = 2,
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(two, Ok(Enum::Other));
+
+    const max_value: Result<Enum, ConstTryFromPrimitiveError<Enum>> =
+        Enum::const_try_from(u8::max_value());
+    assert_eq!(
+        max_value.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `255`"
+    );
+}
+
+#[test]
+fn alternative_values_and_default_value() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        #[num_enum(default)]
+        Zero = 0,
+        One = 1,
+        #[num_enum(alternatives = [3])]
+        TwoOrThree = 2,
+        Four = 4,
+    }
+
+    const zero: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0u8);
+    assert_eq!(zero, Ok(Enum::Zero));
+
+    const one: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(1u8);
+    assert_eq!(one, Ok(Enum::One));
+
+    const two: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(2u8);
+    assert_eq!(two, Ok(Enum::TwoOrThree));
+
+    const three: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(3u8);
+    assert_eq!(three, Ok(Enum::TwoOrThree));
+
+    const four: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(4u8);
+    assert_eq!(four, Ok(Enum::Four));
+
+    const five: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(5u8);
+    assert_eq!(
+        five.unwrap_err().to_string(),
+        "No discriminant in enum `Enum` matches the value `5`"
+    );
+}
+
+#[test]
+fn try_from_primitive_number() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[repr(u8)]
+    enum Enum {
+        #[num_enum(default)]
+        Whatever = 0,
+    }
+
+    // #[derive(FromPrimitive)] generates implementations for the following traits:
+    //
+    // - `ConstTryFromPrimitive<T>`
+    // - `TryFrom<T>`
+
+    const try_from_primitive: Result<Enum, ConstTryFromPrimitiveError<Enum>> =
+        Enum::const_try_from(0_u8);
+    assert_eq!(try_from_primitive, Ok(Enum::Whatever));
+
+    const try_from: Result<Enum, ConstTryFromPrimitiveError<Enum>> = Enum::const_try_from(0_u8);
+    assert_eq!(try_from, Ok(Enum::Whatever));
+}
+
+#[test]
+fn custom_error() {
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[num_enum(error_type(name = CustomError, constructor = CustomError::new))]
+    #[repr(u8)]
+    enum FirstNumber {
+        Zero,
+        One,
+        Two,
+    }
+
+    #[derive(Debug, Eq, PartialEq, ConstTryFromPrimitive)]
+    #[num_enum(error_type(constructor = CustomError::new, name = CustomError))]
+    #[repr(u8)]
+    enum SecondNumber {
+        Zero,
+        One,
+        Two,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct CustomError {
+        bad_value: u8,
+    }
+
+    impl CustomError {
+        const fn new(value: u8) -> CustomError {
+            CustomError { bad_value: value }
+        }
+    }
+
+    let zero: Result<FirstNumber, _> = FirstNumber::const_try_from(0u8);
+    assert_eq!(zero, Ok(FirstNumber::Zero));
+
+    let three: Result<FirstNumber, _> = FirstNumber::const_try_from(3u8);
+    assert_eq!(three.unwrap_err(), CustomError { bad_value: 3u8 });
+
+    let three: Result<SecondNumber, _> = SecondNumber::const_try_from(3u8);
+    assert_eq!(three.unwrap_err(), CustomError { bad_value: 3u8 });
+}
+
+// #[derive(FromPrimitive)] generates implementations for the following traits:
+//
+// - `FromPrimitive<T>`
+// - `From<T>`
+// - `ConstTryFromPrimitive<T>`
+// - `TryFrom<T>`


### PR DESCRIPTION
# Motivation

`num_enum` is very effective for manipulating data representations at runtime. However, there are some cases where we might want this functionality in `const` contexts, such as when generating `static` values or composing `num_enum` types into other `Copy` structs which we also want to manipulate in `const` contexts.

## Alternatives
- Note that while I have *wanted* this feature for both https://github.com/signalapp/libsignal and https://github.com/zip-rs/zip2, I cannot say that it is truly *necessary*, just *convenient*.
- Certain nightly features such as `const_trait_impl` and `effects` are able to avoid the need for parts of this, by making `From`/`Into`/`Default` impls `const`-compatible, so for my other work that uses nightly, I actually don't require these at all!
    - However, I don't believe those features are expected to be stabilized soon, and I think it makes sense to have explicit/separate `const` and non-`const` methods for `num_enum` derives until Rust has developed a more formal mechanism for manipulating `const` effects.

# Implementation
Four new derive macros were added, along with auxiliary traits/structs in `lib.rs` as needed. Since traits can't define `const fn`s, all of these instead generate a method on the enum directly:
- `ConstIntoPrimitive`: `const_into(self) -> #repr`
- `ConstFromPrimitive`: `const_from(#repr) -> Self`
- `ConstTryFromPrimitive`: `const_try_from(#repr) -> Result<Self, ConstTryFromPrimitiveError<Self>>`
- `ConstDefault`: `const_default() -> Self`

# Result
The boilerplate that `num_enum` generates no longer has be written by hand when using a `num_enum` type in `const` contexts!