### PR TITLE
Bump trybuild to 1.0.98, and MSRV to 1.70.0

### DIFF
--- a/.github/workflows/msrv-build.yml
+++ b/.github/workflows/msrv-build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56.0
+          toolchain: 1.70.0
           target: thumbv6m-none-eabi
       - name: Use MSRV Cargo.lock
         run: cp Cargo.lock.msrv Cargo.lock
@@ -24,10 +24,10 @@ jobs:
         with:
           command: build
           args: --all --locked
-          toolchain: 1.56.0
+          toolchain: 1.70.0
       - name: Build no-std with MSRV
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --manifest-path=num_enum/Cargo.toml --target thumbv6m-none-eabi --no-default-features --locked
-          toolchain: 1.56.0
+          toolchain: 1.70.0

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -21,14 +21,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497049e9477329f8f6a559972ee42e117487d01d1e8c2cc9f836ea6fa23a9e1a"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.0"
+name = "equivalent"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edd69c67b2f8e0911629b7e6b8a34cb3956613cd7c6e6414966dee349c2db4f"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "glob"
@@ -43,20 +43,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "indexmap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.0",
 ]
 
 [[package]]
-name = "itoa"
-version = "0.3.0"
+name = "indexmap"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd9dc2c587067de817fec4ad355e3818c3d893a78cab32a0a474c7a15bb8d5"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+]
 
 [[package]]
 name = "itoa"
@@ -75,10 +85,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.3.0"
+name = "memchr"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "metadata_check"
@@ -88,12 +98,6 @@ dependencies = [
  "serde",
  "serde_yaml",
 ]
-
-[[package]]
-name = "num-traits"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51eab148f171aefad295f8cece636fc488b9b392ef544da31ea4b8ef6b9e9c39"
 
 [[package]]
 name = "num_enum"
@@ -114,7 +118,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.0",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -130,23 +134,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
 dependencies = [
  "thiserror",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -182,22 +186,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.90",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -210,13 +214,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.0"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b1ec939469a124b27e208106550c38358ed4334d2b1b5b3825bc1ee37d946a"
+checksum = "6fbd975230bada99c8bb618e0c365c2eefa219158d5c6c29610fd09ff1833257"
 dependencies = [
- "dtoa",
- "itoa 0.3.0",
- "num-traits",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
  "serde",
 ]
 
@@ -226,8 +238,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35a3320a1c8ead0efb4bf508678e8dc29a1bd89118b2f9eae2dccb5123b1a69"
 dependencies = [
- "indexmap",
- "itoa 1.0.0",
+ "indexmap 1.9.0",
+ "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -243,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "ea9c5432ff16d6152371f808fb5a871cd67368171b09bb21b43df8e4a47a3556"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -254,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.0"
+version = "2.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cff13bb1732bccfe3b246f3fdb09edfd51c01d6f5299b7ccd9457c2e4e37774"
+checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -289,7 +301,7 @@ checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.90",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -302,17 +314,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "trybuild"
-version = "1.0.49"
+name = "toml"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b533b653278ed89f93da2508e324ce9c7ef4af686521ebe4e6516fc9f3fd8d"
+checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55265878356bdd85c9baa15859c87de93b2bf1f33acf752040a561e4a228f62"
 dependencies = [
  "glob",
- "lazy_static",
  "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
- "toml",
+ "toml 0.8.0",
 ]
 
 [[package]]
@@ -383,4 +429,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9dc3aa9dcda98b5a16150c54619c1ead22e3d3a5d458778ae914be760aa981a"
 dependencies = [
  "winapi 0.3.0",
+]
+
+[[package]]
+name = "winnow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+dependencies = [
+ "memchr",
 ]

--- a/num_enum/Cargo.toml
+++ b/num_enum/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "num_enum"
 version = "0.7.2"  # Keep in sync with num_enum_derive, the the dependency on it below.
-rust-version = "1.56.0"
+rust-version = "1.70.0"
 authors = [
   "Daniel Wagner-Hall <dawagner@gmail.com>",
   "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
@@ -36,5 +36,5 @@ num_enum_derive = { version = "=0.7.2", path = "../num_enum_derive", default-fea
 anyhow = "1.0.14"
 paste = "1"
 rustversion = "1.0.4"
-trybuild = "1.0.49"
+trybuild = "1.0.98"
 walkdir = "2"

--- a/num_enum_derive/Cargo.toml
+++ b/num_enum_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "num_enum_derive"
 version = "0.7.2"  # Keep in sync with num_enum.
-rust-version = "1.56.0"
+rust-version = "1.70.0"
 authors = [
   "Daniel Wagner-Hall <dawagner@gmail.com>",
   "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",

--- a/serde_example/Cargo.toml
+++ b/serde_example/Cargo.toml
@@ -13,4 +13,4 @@ publish = false
 
 [dependencies]
 num_enum = { path = "../num_enum", default-features = false }
-serde = { version = "1", default_features = false, features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive"] }

--- a/stress_tests/Cargo.toml
+++ b/stress_tests/Cargo.toml
@@ -13,4 +13,4 @@ publish = false
 
 [dev-dependencies]
 num_enum = { path = "../num_enum" }
-trybuild = "1.0.31"
+trybuild = "1.0.98"


### PR DESCRIPTION
This necessitates bumping MSRV to 1.70.0, which is a significant change from 1.56.0.

1.70.0 was more than a year ago, and seems like a reasonable bump, but it's a bit unfortunate that we're doing this bump only for a test-only dependency.

As we're not actually changing any production code here, things are likely to continue to work with older rust versions, but we will not continue testing this, and make no promises versions older than 1.70.0 will keep working.