### PR TITLE
Remove travis badge

### DIFF
--- a/num_enum/Cargo.toml
+++ b/num_enum/Cargo.toml
@@ -26,7 +26,6 @@ default = ["std"]  # disable to use in a `no_std` environment
 features = ["external_doc"]
 
 [badges]
-travis-ci = { repository = "illicitonion/num_enum", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]


### PR DESCRIPTION
We haven't used travis in a number of years, and also badges are no longer a Cargo.toml thing.