### PR TITLE
Use `core::error::Error` when available

### DIFF
--- a/num_enum/Cargo.toml
+++ b/num_enum/Cargo.toml
@@ -29,11 +29,11 @@ features = ["external_doc"]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
+rustversion = "1.0.4"
 num_enum_derive = { version = "=0.7.3", path = "../num_enum_derive", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.14"
 paste = "1"
-rustversion = "1.0.4"
 trybuild = "1.0.98"
 walkdir = "2"

--- a/num_enum/src/lib.rs
+++ b/num_enum/src/lib.rs
@@ -81,7 +81,11 @@ impl<Enum: TryFromPrimitive> fmt::Display for TryFromPrimitiveError<Enum> {
     }
 }
 
+#[rustversion::since(1.81)]
+impl<Enum: TryFromPrimitive> ::core::error::Error for TryFromPrimitiveError<Enum> {}
+
 #[cfg(feature = "std")]
+#[rustversion::before(1.81)]
 impl<Enum: TryFromPrimitive> ::std::error::Error for TryFromPrimitiveError<Enum> {}
 
 // This trait exists to try to give a more clear error message when someone attempts to derive both FromPrimitive and TryFromPrimitive.


### PR DESCRIPTION
The `Error` trait has been in `core` since 1.81.

This PR implements `Error` for `TryFromPrimitiveError` even without the `std` feature for toolchains since 1.81.