### PR TITLE
Update to proc-macro-crate v3

### DIFF
--- a/num_enum_derive/Cargo.toml
+++ b/num_enum_derive/Cargo.toml
@@ -33,7 +33,7 @@ features = ["external_doc"]
 
 [dependencies]
 proc-macro2 = "1.0.60"
-proc-macro-crate = { version = ">= 1, <= 3", optional = true }
+proc-macro-crate = { version = "3", optional = true }
 quote = "1"
 syn = { version = "2", features = ["parsing"] }
 


### PR DESCRIPTION
`proc-macro-crate` v2 pins to exact versions of its `toml_edit` and `toml_datetime` dependencies. As these pinned versions get older, it is increasingly likely that crates that depend on `num_enum` will see a conflict with another dependency that sets a minimum version for one of these crates.