### PR TITLE
Add no_panic attribute for FromPrimitive

### DIFF
--- a/num_enum_derive/src/lib.rs
+++ b/num_enum_derive/src/lib.rs
@@ -121,12 +121,19 @@ pub fn derive_from_primitive(input: TokenStream) -> TokenStream {
     let expression_idents: Vec<Vec<Ident>> = enum_info.expression_idents();
     let variant_expressions: Vec<Vec<Expr>> = enum_info.variant_expressions();
 
+    let no_panic_attr = if enum_info.no_panic {
+        quote!(#[no_panic::no_panic])
+    } else {
+        quote!()
+    };
+
     debug_assert_eq!(variant_idents.len(), variant_expressions.len());
 
     TokenStream::from(quote! {
         impl ::#krate::FromPrimitive for #name {
             type Primitive = #repr;
 
+            #no_panic_attr
             fn from_primitive(number: Self::Primitive) -> Self {
                 // Use intermediate const(s) so that enums defined like
                 // `Two = ONE + 1u8` work properly.


### PR DESCRIPTION
Added a new attribute: `#[num_enum(from_primitive(no_panic))]`, with alternative syntax of `#[num_enum(from_primitive(no_panic=true))]`.
this configuration is off by default.

this configuration generates a `#[no_panic::no_panic]` attribute on the (from this crate https://docs.rs/no-panic/latest/no_panic/)  `from_primitive()` methods generated by `#[derive(FromPrimitive)]`

I made A POC that's works on my machine with manual tests.

If you are willing to accept such feature, I will add the necessary tests & docs.
I am open to make changes according to feedback.

example code from my project:
```rust
#[derive(Debug, IntoPrimitive, FromPrimitive)]
#[num_enum(from_primitive(no_panic))]
#[repr(isize)]
#[non_exhaustive]
pub enum Errno {
    EPERM = EPERM,
    ENOENT = ENOENT,
    // many more variants ...
    EHWPOISON = EHWPOISON,
    #[num_enum(catch_all)]
    Unknown(isize),
}

#[no_panic::no_panic]
pub unsafe fn syscall6w(
    no: isize,
    arg0: isize,
    arg1: isize,
    arg2: isize,
    arg3: isize,
    arg4: isize,
    arg5: isize,
) -> Result<isize, SyscallError> {
    let result = syscall6(no, arg0, arg1, arg2, arg3, arg4, arg5);

    if result as usize > -4096isize as usize {
        Err(SyscallError(no, Errno::from_primitive(-result)))
    } else {
        Ok(result)
    }
}

```
